### PR TITLE
H14 - Média de Gastos por Categoria em um Período

### DIFF
--- a/BACK/Gastos/urls.py
+++ b/BACK/Gastos/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path('gastos-per-tag-por-pago/', GastoApiView.pegar_gasto_tag_filter_pago, name='gastos-da-tag-filtrar-por-pago'),
     path('total-gastos-meses-anteriores/', GastoApiView.get_total_gastos_meses_anteriores, name='total-gastos-meses-anteriores'),
     path('gastos-mais-relevantes/', GastoApiView.get_gastos_mais_relevantes, name='gastos-mais-relevantes'),
+    path('media-mensal-por-tag-em-periodo/', GastoApiView.get_media_mensal_por_tag_em_periodo, name='media-mensal-por-tag-em-periodo'),
 ]

--- a/FRONT/src/components/BarChart/index.jsx
+++ b/FRONT/src/components/BarChart/index.jsx
@@ -30,11 +30,14 @@ export const barOptions = {
     responsive: true,
     plugins: {
         legend: {
-            position: 'top',
+            position: 'bottom',
         },
         title: {
             display: true,
             text: 'Média Mensal de Gastos por Categoria em um Período',
+            font: {
+                size: 18,
+            }
         },
     },
 };
@@ -119,12 +122,12 @@ export default function BarChartComponent() {
     ];
     
     return (
-        <div className="DonutChartContainer">
+        <div className="BarChartContainer">
             <Bar options={barOptions} data={barChartData} />
             
-            <div className="month-year-input-container">
+            <div className="period-input">
 
-                <select className="month-input" value={period} onChange={handleSelectPeriodChange}>
+                <select className="input" value={period} onChange={handleSelectPeriodChange}>
 
                     {options.map((option) => (
                         <option key={option.value} value={option.value}>

--- a/FRONT/src/components/BarChart/index.jsx
+++ b/FRONT/src/components/BarChart/index.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { useState, useEffect } from 'react';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+
+import './style.css';
+import axios from 'axios';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+
+// Configurações do gráfico de Barras
+export const barOptions = {
+    responsive: true,
+    plugins: {
+        legend: {
+            position: 'top',
+        },
+        title: {
+            display: true,
+            text: 'Média Mensal de Gastos por Categoria em um Período',
+        },
+    },
+};
+
+
+// Dados do gráfico de Barras
+export const barChartData = {
+    labels: [],                                          // Período (string)
+    datasets: [
+        // {
+        //   label: 'Dataset 1',                         // categoria
+        //   data:                                       // média
+        //   backgroundColor: 'rgba(255, 99, 132, 0.5)', // cor
+        // },
+    ],
+};
+
+
+
+// componente gráfico de Barras para exibir a média mensal de gastos por categoria durante um período específico
+export default function BarChartComponent() {
+
+    const [chartData, setChartData] = useState(null);
+    const [period, setPeriod] = useState(3);
+    
+    const handleSelectPeriodChange = (event) => {
+        setPeriod(event.target.value);
+    };
+    
+    // carrega os dados do gráfico de Barras por meio da API do Back
+    useEffect(() => {
+
+        const fetchBarChartData = async () => {
+
+            const user = localStorage.getItem("cadastro_user");
+            const periodo = period;
+
+            const request = {
+                user,
+                periodo,
+            };
+            
+            console.log("request: ", request)
+            
+            axios.post('http://localhost:8000/api/gastos/media-mensal-por-tag-em-periodo/', request)
+                .then(response => {
+                    const json_response = response.data
+                    console.log("response: ", json_response)
+                    setChartData(json_response);
+                })
+                .catch(error => {
+                    console.log("Erro ao enviar/receber dados.", error);
+                    setChartData(null);
+                });
+        };
+        
+        setChartData(null);
+        fetchBarChartData();
+
+    }, [period]);
+
+    if (!chartData) {
+        return <h1>Carregando Gráficos...</h1>;
+    }
+    
+    // atribuindo o conteúdo da resposta do Back para barChartData
+    const labels = [];
+    labels[0] = chartData["labels"]
+
+    barChartData.labels[0] = chartData["labels"]
+    
+    barChartData.datasets = chartData["datasets"]
+    
+    // console.log("DATASETS: ", barChartData.datasets)
+
+    const options = [
+        { value: 3, label: '3 meses' },
+        { value: 6, label: '6 meses' },
+        { value: 12, label: '12 meses' },
+        { value: 24, label: '24 meses' },
+        { value: 36, label: '36 meses' },
+    ];
+    
+    return (
+        <div className="DonutChartContainer">
+            <Bar options={barOptions} data={barChartData} />
+            
+            <div className="month-year-input-container">
+
+                <select className="month-input" value={period} onChange={handleSelectPeriodChange}>
+
+                    {options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+
+                </select>
+
+            </div>
+
+        </div>
+    );
+}

--- a/FRONT/src/components/BarChart/style.css
+++ b/FRONT/src/components/BarChart/style.css
@@ -1,61 +1,48 @@
-.DonutChartContainer {
-    max-height: 62%;
-    width: 40%;
+.BarChartContainer {
+    height: 100%;
+    width: 55%;
+
     display: flex;
+    /* justify-content: space-around; */
     flex-direction: column;
     align-items: center;
-    padding: 2%;
-
+    
+    padding: 1% 2% 0%;
+    position: relative;
+    
     border-radius: 5%;
     box-shadow:  6px 6px 12px #aeaeae,
-             -6px -6px 12px #f0f0f0;
+    -6px -6px 12px #f0f0f0;
 
-    position: relative;
 }
 
 @media screen and (max-width: 1000px) {
-    .DonutChartContainer {
-        height: 65%;
-        width: 50%;
+    .BarChartContainer {
+        height: 100%;
+        width: 80%;
         display: flex;
         justify-content: center;
-        padding: 3% 2% 4%;
-        margin: 4%;
+        /* padding: 3% 2% 4%; */
     }
-
-    /* alterar os outros tbm */
 }
 
-.DonutChartComponent {
-    height: calc(100% - 75%);
-    width: 100%;
-    
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    top: 2%;
-    position: absolute;
-    
-    /* border: solid 1px red; */
-}
-
-.month-year-input-container {
-    height: calc(100% - 90%);
+.period-input {
+    height: 10%;
     width: 80%;
     
     display: flex;
     flex-direction: row;
-    justify-content: bottom;
     align-items: center;
     position: absolute;
     bottom: 0;
     
+    justify-content: space-around;
+    
     /* border: 1px solid red; */
-    justify-content: space-evenly;
     /* color: white; */
 }
 
-.month-input, .year-input {
+.input {
     margin: 0 -15%;
     width: 17%;
     
@@ -64,6 +51,12 @@
     border: none;
 }
 
-.month-input:hover, .year-input:hover {
+.input:hover {
     cursor: pointer;
+}
+
+@media screen and (min-width: 1400px) {
+    .BarChartContainer canvas {
+        max-height: 87%;
+    }    
 }

--- a/FRONT/src/components/BarChart/style.css
+++ b/FRONT/src/components/BarChart/style.css
@@ -1,0 +1,69 @@
+.DonutChartContainer {
+    max-height: 62%;
+    width: 40%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2%;
+
+    border-radius: 5%;
+    box-shadow:  6px 6px 12px #aeaeae,
+             -6px -6px 12px #f0f0f0;
+
+    position: relative;
+}
+
+@media screen and (max-width: 1000px) {
+    .DonutChartContainer {
+        height: 65%;
+        width: 50%;
+        display: flex;
+        justify-content: center;
+        padding: 3% 2% 4%;
+        margin: 4%;
+    }
+
+    /* alterar os outros tbm */
+}
+
+.DonutChartComponent {
+    height: calc(100% - 75%);
+    width: 100%;
+    
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    top: 2%;
+    position: absolute;
+    
+    /* border: solid 1px red; */
+}
+
+.month-year-input-container {
+    height: calc(100% - 90%);
+    width: 80%;
+    
+    display: flex;
+    flex-direction: row;
+    justify-content: bottom;
+    align-items: center;
+    position: absolute;
+    bottom: 0;
+    
+    /* border: 1px solid red; */
+    justify-content: space-evenly;
+    /* color: white; */
+}
+
+.month-input, .year-input {
+    margin: 0 -15%;
+    width: 17%;
+    
+    background-color: var(--dark-gray);
+    color: var(--60-background-dark);
+    border: none;
+}
+
+.month-input:hover, .year-input:hover {
+    cursor: pointer;
+}

--- a/FRONT/src/components/DoughnutChart/index.jsx
+++ b/FRONT/src/components/DoughnutChart/index.jsx
@@ -61,7 +61,7 @@ export const doughnutOptions = {
     responsive: true,
     plugins: {
         legend: {
-            position: 'bottom',
+            position: 'right',
         },
         title: {
             display: true,

--- a/FRONT/src/components/DoughnutChart/style.css
+++ b/FRONT/src/components/DoughnutChart/style.css
@@ -1,5 +1,5 @@
 .DonutChartContainer {
-    max-height: 62%;
+    height: 100%;
     width: 40%;
     display: flex;
     flex-direction: column;
@@ -15,15 +15,12 @@
 
 @media screen and (max-width: 1000px) {
     .DonutChartContainer {
-        height: 65%;
-        width: 50%;
+        height: 50%;
+        width: 60%;
         display: flex;
         justify-content: center;
         padding: 3% 2% 4%;
-        margin: 4%;
     }
-
-    /* alterar os outros tbm */
 }
 
 .DonutChartComponent {

--- a/FRONT/src/components/LineChart/index.jsx
+++ b/FRONT/src/components/LineChart/index.jsx
@@ -54,7 +54,7 @@ export const lineChartOptions = {
       display: true,
       text: 'Total de Gastos dos Meses Anteriores',
       font: {
-        size: 20
+        size: 18,
       }
     },
   },

--- a/FRONT/src/components/LineChart/style.css
+++ b/FRONT/src/components/LineChart/style.css
@@ -1,10 +1,12 @@
 .LineChartComponent {
-    height: 62%; /* 65% */
-    width: auto; /* 55% */
-    min-width: 55%;
+    height: 80%;
+    width: 55%; /* 55% */
+    
     display: flex;
     justify-content: center;
-    padding: 4% 2% 3%;
+    
+    padding: 1% 0% 1.2% 0%;
+    /* margin: 0 0 10% 0; */
     position: relative;
     
     /* border: 1px solid var(--dark); */
@@ -16,10 +18,18 @@
 
 @media screen and (max-width: 1000px) {
     .LineChartComponent {
-        height: 45%;
-        width: 60%;
-        padding: 4% 2% 4%;
+        height: 50%;
+        width: 75%;
+        /* padding: 4% 2% 4%; */
         justify-content: center;
-        margin: 4%;
+        /* margin: 4%; */
     }
 }
+
+@media screen and (min-width: 1350px) {
+    .LineChartComponent {
+        height: 100%;
+        padding: 1% 1.2% 0% 1.2%;
+    }
+  }
+  

--- a/FRONT/src/pages/Graficos/index.jsx
+++ b/FRONT/src/pages/Graficos/index.jsx
@@ -5,10 +5,10 @@ import '../../main.css';
 import LineChartComponent from '../../components/LineChart';
 import DoughnutChartComponent from '../../components/DoughnutChart';
 import Sidebar from '../../components/sidebar';
+import BarChartComponent from '../../components/BarChart';
 
 
-
-// componente que renderiza a página toda (todos os gráficos/componentes)
+// componente que renderiza a página Dasboard (todos os gráficos/componentes)
 export default function Graficos() {
 
   const username = localStorage.getItem('cadastro_user');
@@ -31,8 +31,16 @@ export default function Graficos() {
           </header>
 
           <div className='body-dashboard'>
-            <LineChartComponent/>
-            <DoughnutChartComponent/>
+            
+            <div className='first-chart-container'>
+              <LineChartComponent/>
+              <DoughnutChartComponent/>
+            </div>
+
+            <div className='second-chart-container'>
+              <BarChartComponent/>
+            </div>
+
           </div>
 
         </div>

--- a/FRONT/src/pages/Graficos/style.css
+++ b/FRONT/src/pages/Graficos/style.css
@@ -10,6 +10,10 @@
 }
 
 .body-dashboard {
+  flex-direction: column;
+}
+
+.first-chart-container {
   width: 100%;
   min-height: calc(100vh - 12vh);
   
@@ -23,7 +27,25 @@
   gap: 2.8em;
   /* flex-wrap: wrap; */
   
-  /* border: 1px solid blue; */
+  border: 1px solid blue;
+  background-color: var(--10-gray);
+}
+
+.second-chart-container {
+  width: 100%;
+  min-height: calc(100vh - 12vh);
+  
+  margin: 0;
+  padding: 3% 1.5% 1.5% 1.5%;
+  flex-direction: row;
+  position: relative;
+
+  display: flex;
+  justify-items: space-evenly;
+  gap: 2.8em;
+  /* flex-wrap: wrap; */
+  
+  border: 1px solid greenyellow;
   background-color: var(--10-gray);
 }
 

--- a/FRONT/src/pages/Graficos/style.css
+++ b/FRONT/src/pages/Graficos/style.css
@@ -11,51 +11,66 @@
 
 .body-dashboard {
   flex-direction: column;
+  min-height: calc(100vh - 12vh);
 }
 
 .first-chart-container {
   width: 100%;
-  min-height: calc(100vh - 12vh);
-  
+  height: 50%;
+
   margin: 0;
-  padding: 3% 1.5% 1.5% 1.5%;
+  padding: 2% 4.5% 1.3% 4.5%;
   flex-direction: row;
   position: relative;
-
+  
   display: flex;
-  justify-items: space-evenly;
+  justify-content: space-around;
+  align-items: center;
   gap: 2.8em;
   /* flex-wrap: wrap; */
   
-  border: 1px solid blue;
+  /* border: 1px solid red; */
   background-color: var(--10-gray);
 }
 
 .second-chart-container {
   width: 100%;
-  min-height: calc(100vh - 12vh);
+  height: 50%;
   
   margin: 0;
-  padding: 3% 1.5% 1.5% 1.5%;
+  padding: 1.5% 1.5% 1.5% 1.5%;
   flex-direction: row;
   position: relative;
 
   display: flex;
+  justify-content: center;
   justify-items: space-evenly;
   gap: 2.8em;
   /* flex-wrap: wrap; */
   
-  border: 1px solid greenyellow;
+  /* border: 1px solid greenyellow; */
   background-color: var(--10-gray);
 }
 
 @media screen and (max-width: 1000px) {
-  .GraficosPage {
-    display: flex;
-    padding: 3%;
+  .first-chart-container {
+    height: 100%;
+    padding-top: 5%;
     flex-direction: column;
-    justify-content: space-around;
-    align-items: center;
+  }
+
+  .second-chart-container {
+    height: 60%;
+    padding-top: 3%;
+  }
+  
+  .GraficosPage {
+    /* height: 200vh; */
+    
+    display: flex;
+    /* flex-direction: column; */
+    /* justify-content: space-around; */
+
   }
 }
 


### PR DESCRIPTION
### Este pull request finaliza a História 14 que corresponde à criação de um gráfico para visualizar a média mensal de todas as categorias de gastos do usuário  em um dado período de tempo.
<br>

#### Alterações feitas a serem testadas/revisadas:

#### Back
- [ ] Nova URL/API/endpoint do gráfico que devolve as informações a serem exibidas no gráfico de acordo com o período especificado na requisição.
  - podendo ser acessado por meio da URL `http://localhost:8000/api/gastos/media-mensal-por-tag-em-periodo/` enviando o `username` e o `periodo` (quantidade de meses).
- [ ] Nova função `get_media_mensal_por_tag_em_periodo` na View de gastos para, dado um `username` e um `periodo` como requisição, retornar um json com dois arrays: `datasets` e `labels`.
  - O array `labels` deve conter a string "Últimos `<período>` meses" a partir do mês atual.
  - O array `datasets` deve conter, em cada posição, um dicionário com: a média de gastos daquela categoria de gastos no dito período, o nome dessa categoria e sua cor em RGBA.
- [ ] Nova função `hex_to_rgba` para converter a cor da tag de hexadecimal para RGBA.


#### Front
- [ ] Criação do componente `BarChart` para exibir o gráfico com a média mensal de todas as categorias de gastos do usuário  em um dado período de tempo, por meio dos arrays `datasets` e `labels`.
- [ ] Criação da função `fetchBarChartData` para fazer a requisição à API do Back-end especificada acima, enviando o nome do usuário e o período desejado em quantidade de meses.
- [ ] Criação de um menu drop down para o usuário escolher quantos meses a partir do atual ele deseja visualizar as médias das categorias de gastos.
- [ ] Pequenos ajustes no Dashboard para uma mínima responsividade.